### PR TITLE
Integrate FullScreenSlider into ComposerCard

### DIFF
--- a/app/components/ComposerCard.tsx
+++ b/app/components/ComposerCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useRef, useState } from "react";
 import { motion } from "framer-motion";
+import FullScreenSlider from "./FullScreenSlider";
 
 interface SubItem {
   immagine_o_testo?: "img" | "txt" | "";
@@ -28,6 +29,8 @@ interface ComposerCardProps {
 const ComposerCard: React.FC<ComposerCardProps> = ({ item }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number>(800);
+  const [isSliderOpen, setIsSliderOpen] = useState(false);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
   if (!item) return null;
 
@@ -36,6 +39,24 @@ const ComposerCard: React.FC<ComposerCardProps> = ({ item }) => {
     item.immagine_2,
     item.immagine_3,
   ].filter(Boolean) as SubItem[];
+
+  const imagesForSlider = subItemsRaw
+    .filter(
+      (sub) => sub.immagine_o_testo === "img" && sub.immagine && sub.immagine.url
+    )
+    .map((sub) => ({
+      src: sub.immagine!.url!,
+      alt: sub.immagine!.alt || "Project image",
+    }));
+
+  const handleImageClick = (index: number) => {
+    setSelectedImageIndex(index);
+    setIsSliderOpen(true);
+  };
+
+  const handleCloseSlider = () => {
+    setIsSliderOpen(false);
+  };
 
   const itemVariants = {
     hidden: { opacity: 0 },
@@ -66,7 +87,10 @@ const ComposerCard: React.FC<ComposerCardProps> = ({ item }) => {
         top: `${topImg}%`,
         width: `${largImg}%`,
         transform: `translateY(-50%)`,
+        cursor: "pointer",
       };
+
+      const imageIndex = imagesForSlider.findIndex((img) => img.src === url);
 
       return (
         <motion.img
@@ -75,6 +99,7 @@ const ComposerCard: React.FC<ComposerCardProps> = ({ item }) => {
           alt={alt}
           style={style}
           className="absolute object-contain"
+          onClick={() => handleImageClick(imageIndex)}
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, amount: 0.2 }}
@@ -124,6 +149,13 @@ const ComposerCard: React.FC<ComposerCardProps> = ({ item }) => {
       style={{ minHeight: `${height}px` }}
     >
       {subItemsRaw.map((s, i) => renderSubItem(s, i))}
+      {isSliderOpen && (
+        <FullScreenSlider
+          images={imagesForSlider}
+          initialIndex={selectedImageIndex}
+          onClose={handleCloseSlider}
+        />
+      )}
     </div>
   );
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "vs.ferdinandocambiale.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This change integrates the `FullScreenSlider` component into the `ComposerCard` to allow users to view images in a fullscreen modal.

Key changes:
- Imported `FullScreenSlider` and added state management for its visibility and the selected image index in `ComposerCard.tsx`.
- Implemented a click handler on images within `ComposerCard` that opens the slider and sets the initial image correctly.
- Created a filtered list of images to pass to the slider, ensuring only valid images are included.
- Updated `next.config.ts` to whitelist the external image domain (`vs.ferdinandocambiale.com`), which is required by the `next/image` component to load the project images.