### PR TITLE
Fix ProjectsMenu functionality and page loading

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,34 +1,9 @@
-import Menu, { MenuItem } from "@/components/Menu";
 import React from "react";
 
-async function getMenuItems(): Promise<MenuItem[]> {
-  try {
-    const res = await fetch(
-      `https://vs.ferdinandocambiale.com/wp-json/wp/v2/menu`,
-      { next: { revalidate: 3600 } }
-    );
-    if (!res.ok) {
-      console.error("Failed to fetch menu items:", res.statusText);
-      return [];
-    }
-    return res.json();
-  } catch (error) {
-    console.error("Error fetching menu items:", error);
-    return [];
-  }
-}
-
-export default async function MainLayout({
+export default function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const menuItems = await getMenuItems();
-
-  return (
-    <>
-      <Menu menuItems={menuItems} />
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { notFound } from "next/navigation";
-import Menu, { MenuItem } from "@/components/Menu";
-import ProjectContent from "@/components/ProjectContent"; // nuovo client component
+import ProjectPageClient from "@/components/ProjectPageClient";
 
 export const dynamic = "force-dynamic";
 
@@ -29,41 +28,22 @@ async function getProject(slug: string): Promise<Progetto> {
   return projects[0];
 }
 
-async function getMenuItems(): Promise<MenuItem[]> {
-  try {
-    const res = await fetch(
-      `https://vs.ferdinandocambiale.com/wp-json/wp/v2/menu`,
-      { next: { revalidate: 3600 } }
-    );
-    if (!res.ok) return [];
-    return res.json();
-  } catch {
-    return [];
-  }
-}
-
 export default async function ProjectPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
-
-  const [project, menuItems] = await Promise.all([
-    getProject(slug),
-    getMenuItems(),
-  ]);
-
+  const { slug } = params;
+  const project = await getProject(slug);
   const pageTitle = project.acf.titolo_personalizzato || project.title.rendered;
 
   return (
     <main className="mx-auto pt-24">
-      <Menu menuItems={menuItems} pageTitle={pageTitle} />
       <h1
         className="sr-only"
         dangerouslySetInnerHTML={{ __html: pageTitle }}
       />
-      <ProjectContent project={project} />
+      <ProjectPageClient project={project} pageTitle={pageTitle} />
     </main>
   );
 }

--- a/app/components/Menu.tsx
+++ b/app/components/Menu.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+"use client";
+
 import React, { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Logo from "./Logo";
 import Link from "next/link";
+import { useTitle } from "./TitleContext";
 
 export interface MenuItem {
     ID: number;
@@ -33,11 +36,10 @@ let inactivityTimer: NodeJS.Timeout | null = null;
 
 const Menu = ({
     menuItems,
-    pageTitle,
 }: {
     menuItems: MenuItem[];
-    pageTitle?: string;
 }) => {
+    const { pageTitle, setPageTitle } = useTitle();
     const [isOpen, setIsOpen] = useState(false);
     const nodeRef = useRef<HTMLDivElement>(null);
 
@@ -65,7 +67,7 @@ const Menu = ({
     return (
         <header className="fixed w-full top-4 left-0 right-0 z-50">
             <div className="px-4 flex justify-between items-center">
-                <Link href="/" className="w-1/2">
+                <Link href="/" className="w-1/2" onClick={() => setPageTitle("")}>
                     <h1
                         // Titolo: Cambia colore usando la variabile --foreground
                         className="inline-block max-w-full truncate text-[var(--foreground)] text-xs"

--- a/app/components/ProjectContent.tsx
+++ b/app/components/ProjectContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ComposerCard from "@/components/ComposerCard";
 import FullScreenSlider from "@/components/FullScreenSlider";
 
@@ -39,6 +39,10 @@ const extractAllImages = (composer: any[]): { src: string; alt: string }[] => {
 };
 
 const ProjectContent: React.FC<ProjectContentProps> = ({ project }) => {
+    useEffect(() => {
+        document.body.style.overflow = "auto";
+    }, []);
+
     const allImages = extractAllImages(project.acf.composer);
 
     const [isSliderOpen, setIsSliderOpen] = useState(false);

--- a/app/components/ProjectPageClient.tsx
+++ b/app/components/ProjectPageClient.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React, { useEffect } from 'react';
+import { useTitle } from './TitleContext';
+import ProjectContent from './ProjectContent';
+
+interface Progetto {
+  id: number;
+  slug: string;
+  title: { rendered: string };
+  acf: {
+    composer: any[];
+    titolo_personalizzato?: string;
+  };
+}
+
+interface ProjectPageClientProps {
+  project: Progetto;
+  pageTitle: string;
+}
+
+const ProjectPageClient: React.FC<ProjectPageClientProps> = ({ project, pageTitle }) => {
+  const { setPageTitle } = useTitle();
+
+  useEffect(() => {
+    setPageTitle(pageTitle);
+  }, [pageTitle, setPageTitle]);
+
+  return <ProjectContent project={project} />;
+};
+
+export default ProjectPageClient;

--- a/app/components/TitleContext.tsx
+++ b/app/components/TitleContext.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+interface TitleContextType {
+  pageTitle: string;
+  setPageTitle: (title: string) => void;
+}
+
+const TitleContext = createContext<TitleContextType | undefined>(undefined);
+
+export const TitleProvider = ({ children }: { children: ReactNode }) => {
+  const [pageTitle, setPageTitle] = useState('');
+
+  return (
+    <TitleContext.Provider value={{ pageTitle, setPageTitle }}>
+      {children}
+    </TitleContext.Provider>
+  );
+};
+
+export const useTitle = () => {
+  const context = useContext(TitleContext);
+  if (context === undefined) {
+    throw new Error('useTitle must be used within a TitleProvider');
+  }
+  return context;
+};

--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,3 @@
+
+> vittorio-sancipriano@0.1.0 dev
+> next dev --turbopack


### PR DESCRIPTION
- Fixes an issue where pages loaded via ProjectsMenu.tsx would have scrolling locked.
- Enables direct loading of project pages by correcting the `params` prop in `app/[slug]/page.tsx`.
- Refactors the menu and title handling to ensure the page title is consistently updated across all pages.